### PR TITLE
fix getUnit error on non-single property values

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -14,7 +14,8 @@ export const getUnit = measurement => {
     return "px";
   }
 
-  return measurement.match(/^([+-]?(?:\d+|\d*\.\d+))([A-Za-z]*|%)$/)[2];
+  const matchedMeasurement = measurement.match(/^([+-]?(?:\d+|\d*\.\d+))([a-z]*|%)$/);
+  return matchedMeasurement ? matchedMeasurement[2] : null;
 };
 
 export const stripUnit = measurement => parseFloat(measurement);


### PR DESCRIPTION
when calling getUnit with a non-single property value it gives the error `TypeError: Cannot read property '2' of null`
```
"20px 20px 20px 20px".match(/^([+-]?(?:\d+|\d*\.\d+))([a-z]*|%)$/) // null
"20px".match(/^([+-]?(?:\d+|\d*\.\d+))([a-z]*|%)$/)  // ["20px", "20", "px"]
```
so I fixed it by checking if the matched array is null
```
const matchedMeasurement = measurement.match(/^([+-]?(?:\d+|\d*\.\d+))([a-z]*|%)$/);
return matchedMeasurement ? matchedMeasurement[2] : null;
```