### PR TITLE
Fix automated releases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,9 @@
 .eslintrc.json
+.github
+.release-it.json
 .travis.yml
 babel.config.js
+changelog-template.hbs
 coverage
 sandbox
 src

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,7 +1,7 @@
 {
   "hooks": {
     "before:init": "yarn test",
-    "after:bump": "yarn auto-changelog --starting-date 2021-08-23 --package --commit-limit false --template changelog-template.hbs"
+    "after:bump": "yarn auto-changelog --starting-date 2021-08-24 --package --commit-limit false --template changelog-template.hbs"
   },
   "git": {
     "changelog": null,

--- a/.release-it.json
+++ b/.release-it.json
@@ -11,5 +11,8 @@
     "push": true
   },
   "github": { "release": false },
-  "npm": { "publish": true }
+  "npm": {
+    "publish": true,
+    "publishArgs": ["--registry=https://registry.npmjs.org"]
+  }
 }


### PR DESCRIPTION
There are currently three issues with automated releases in this project:
1. The `npm publish` command [exits with an error](https://github.com/galacemiguel/fluid-system/runs/3411458592)
2. Configuration files relating to the automated release process are erroneously included in the package tarball
3. The v1.1.0 header is [duplicated in the changelog](https://github.com/galacemiguel/fluid-system/commit/fa6e618104fe29e123283278aebc73baf30c228e)

These are addressed by https://github.com/galacemiguel/fluid-system/commit/12c98b99a98407b741f0d68142cbcbe8d1c837c8, https://github.com/galacemiguel/fluid-system/commit/670a1b9d2df389e3bbd55cc02ad05778e3caffaa, and https://github.com/galacemiguel/fluid-system/pull/20/commits/4b6b618d50082e802797c651c55e0755b814d387 respectively.